### PR TITLE
Improve Search component types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4332,9 +4332,9 @@
       }
     },
     "@types/react-select": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-3.0.27.tgz",
-      "integrity": "sha512-UBZgS1O/BaXo27F6a5+OGMpOFmpsFWb5HyZ8DyuJ5EOCT57ZKwWS4ko9Eqxb3CzVsyKLAp5BXoZtHZbqaFN7ww==",
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-3.0.28.tgz",
+      "integrity": "sha512-Gfg3a/EPLyUQkfezcCQkmLW1Vz6+ziclJhn8dpBUEYJF3IUoxS81ToAi3ky2xtnAyk2wJFMXLvE73KiUd56yTA==",
       "dev": true,
       "requires": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^12.12.67",
     "@types/react": "^16.14.1",
     "@types/react-dom": "^16.9.8",
-    "@types/react-select": "^3.0.27",
+    "@types/react-select": "^3.0.28",
     "@types/react-table": "^7.0.24",
     "@types/styled-components": "^5.1.3",
     "@types/styled-system": "^5.1.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,9 @@ import "./package/static/styles.css";
 
 export function App() {
   const defaultEntry: SearchOptionType[] = [];
-  const [selectedEntry, setSelectedEntry] = useState<SearchOptionType[]>(
-    defaultEntry
-  );
+  const [selectedEntry, setSelectedEntry] = useState<
+    readonly SearchOptionType[]
+  >(defaultEntry);
 
   return (
     <>
@@ -16,11 +16,9 @@ export function App() {
           { value: "entry2", label: "Second Entry" },
           { value: "entry3", label: "Third Entry" },
         ]}
-        onChange={(
-          selectedOption: SearchValueType<SearchOptionType, boolean>
-        ) => {
+        onChange={(selectedOption: SearchValueType<SearchOptionType, true>) => {
           if (selectedOption) {
-            setSelectedEntry(selectedOption as SearchOptionType[]);
+            setSelectedEntry(selectedOption);
           } else setSelectedEntry(defaultEntry);
         }}
         isMulti

--- a/src/package/components/Search/CustomComponents/NoOptionsMessage.tsx
+++ b/src/package/components/Search/CustomComponents/NoOptionsMessage.tsx
@@ -3,9 +3,10 @@ import { components, OptionTypeBase } from "react-select";
 import { NoticeProps } from "react-select/src/components/Menu";
 import { Typography } from "../../../foundation";
 
-export function NoOptionsMessage<OptionType extends OptionTypeBase>(
-  props: NoticeProps<OptionType, boolean>
-) {
+export function NoOptionsMessage<
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean
+>(props: NoticeProps<OptionType, IsMulti>) {
   const { noOptionsTitle, setInvalidSearch } = props.selectProps;
 
   useEffect(() => {

--- a/src/package/components/Search/Search.tsx
+++ b/src/package/components/Search/Search.tsx
@@ -16,14 +16,15 @@ import {
   placeholderStyles,
   valueContainerStyles,
 } from "./styles";
-import { SearchOptionType } from "./types";
+import { SearchOptionType, SearchValueType } from "./types";
 
-export interface SearchProps extends Props<SearchOptionType, boolean> {
+export interface SearchProps<IsMulti extends boolean>
+  extends Props<SearchOptionType, IsMulti> {
   floatingLabel?: string;
   noOptionsTitle?: string;
 }
 
-export function Search({
+export function Search<IsMulti extends boolean>({
   floatingLabel = "Search",
   noOptionsTitle = "Invalid search",
   autoFocus = false,
@@ -35,8 +36,9 @@ export function Search({
   isSearchable = true,
   noOptionsMessage = () => "No results found for this search",
   placeholder = "",
+  defaultValue,
   ...rest
-}: SearchProps) {
+}: SearchProps<IsMulti>) {
   const [invalidSearch, setInvalidSearch] = useState(false);
   return (
     <ReactSelect
@@ -85,6 +87,9 @@ export function Search({
       noOptionsMessage={noOptionsMessage}
       placeholder={placeholder}
       // menuIsOpen={true} // useful for development
+      // This next line can be removed once
+      // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49908 is released
+      defaultValue={defaultValue as any}
       {...rest}
     />
   );

--- a/src/package/components/Search/Search.tsx
+++ b/src/package/components/Search/Search.tsx
@@ -87,9 +87,6 @@ export function Search<IsMulti extends boolean>({
       noOptionsMessage={noOptionsMessage}
       placeholder={placeholder}
       // menuIsOpen={true} // useful for development
-      // This next line can be removed once
-      // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49908 is released
-      defaultValue={defaultValue as any}
       {...rest}
     />
   );

--- a/src/package/components/Search/stories/examples/EgFiltering.tsx
+++ b/src/package/components/Search/stories/examples/EgFiltering.tsx
@@ -11,11 +11,8 @@ export function EgFiltering() {
         { value: "entry2", label: "Second Entry" },
         { value: "entry3", label: "Third Entry" },
       ]}
-      onChange={(
-        selectedOption: SearchValueType<SearchOptionType, boolean>
-      ) => {
-        if (selectedOption)
-          showToast("Selected: " + (selectedOption as SearchOptionType).label);
+      onChange={(selectedOption: SearchValueType<SearchOptionType, false>) => {
+        if (selectedOption) showToast("Selected: " + selectedOption.label);
         else showToast("Cleared");
       }}
     />

--- a/src/package/components/Search/stories/examples/EgMultiSelectLimit.tsx
+++ b/src/package/components/Search/stories/examples/EgMultiSelectLimit.tsx
@@ -4,9 +4,9 @@ import { SearchOptionType, SearchValueType } from "../../types";
 
 export function EgMultiSelectLimit() {
   const defaultEntry: SearchOptionType[] = [];
-  const [selectedEntry, setSelectedEntry] = useState<SearchOptionType[]>(
-    defaultEntry
-  );
+  const [selectedEntry, setSelectedEntry] = useState<
+    readonly SearchOptionType[]
+  >(defaultEntry);
 
   return (
     <Search
@@ -19,11 +19,9 @@ export function EgMultiSelectLimit() {
               { value: "entry3", label: "Third Entry" },
             ]
       }
-      onChange={(
-        selectedOption: SearchValueType<SearchOptionType, boolean>
-      ) => {
+      onChange={(selectedOption: SearchValueType<SearchOptionType, true>) => {
         if (selectedOption) {
-          setSelectedEntry(selectedOption as SearchOptionType[]);
+          setSelectedEntry(selectedOption);
         } else setSelectedEntry(defaultEntry);
       }}
       isMulti

--- a/src/package/components/Search/stories/examples/EgSingleSelect.tsx
+++ b/src/package/components/Search/stories/examples/EgSingleSelect.tsx
@@ -14,11 +14,8 @@ export function EgSingleSelect() {
             "Third Entry is a very very long entry that demonstrate text truncations in case of overflow. Decrease screen width to view truncation.",
         },
       ]}
-      onChange={(
-        selectedOption: SearchValueType<SearchOptionType, boolean>
-      ) => {
-        if (selectedOption)
-          showToast("Selected: " + (selectedOption as SearchOptionType).label);
+      onChange={(selectedOption: SearchValueType<SearchOptionType, false>) => {
+        if (selectedOption) showToast("Selected: " + selectedOption.label);
         else showToast("Cleared");
       }}
     />

--- a/src/package/components/Search/stories/examples/EgTheming.tsx
+++ b/src/package/components/Search/stories/examples/EgTheming.tsx
@@ -14,11 +14,8 @@ export function EgTheming() {
         { value: "entry5", label: "Fifth Entry" },
         { value: "entry6", label: "Sixth Entry" },
       ]}
-      onChange={(
-        selectedOption: SearchValueType<SearchOptionType, boolean>
-      ) => {
-        if (selectedOption)
-          showToast("Selected: " + (selectedOption as SearchOptionType).label);
+      onChange={(selectedOption: SearchValueType<SearchOptionType, false>) => {
+        if (selectedOption) showToast("Selected: " + selectedOption.label);
         else showToast("Cleared");
       }}
       theme={(theme) => ({


### PR DESCRIPTION
@cseas Here are some improvements to the types for your `Search` component. Note that all of the casts have been removed from your `onChange` callbacks.

(Note this is a PR into https://github.com/hazel-ui/hazel-ui/pull/52 not `main`)