### PR TITLE
Add support for tree shaking

### DIFF
--- a/src/package/tsconfig.json
+++ b/src/package/tsconfig.json
@@ -1,25 +1,24 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    /* Specify what module code is generated: `CommonJS` (default if `target` is 
+     * `ES3` or `ES5`), `ES2015`, `ES2020`, `None`, `UMD`, `AMD`, `System`, `ESNext`
+     */
+    "module": "ES2015",
+    /* Set the language version for emitted JavaScript: `ES3` (default), `ES5`, 
+     * `ES6`/`ES2015` (synonymous), `ES7`/`ES2016`, `ES2017`, `ES2018`, `ES2019`, 
+     * `ES2020`, or `ESNext`
+     * https://stackoverflow.com/a/42429053/7435656
+     */
+    "target": "es6",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "../../dist" /* Redirect output structure to the directory. */,
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     "removeComments": true /* Do not emit comments to output. */,
-    // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
@@ -39,26 +38,10 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,

--- a/src/package/tsconfig.json
+++ b/src/package/tsconfig.json
@@ -46,5 +46,6 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "skipLibCheck": true /* Skip type checking node_modules */
-  }
+  },
+  "exclude": ["**/*.stories.tsx", "**/*.test.tsx"]
 }

--- a/src/package/tsconfig.json
+++ b/src/package/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    /* Specify what module code is generated: `CommonJS` (default if `target` is 
+    /* Specify what module code is generated: `CommonJS` (default if `target` is
      * `ES3` or `ES5`), `ES2015`, `ES2020`, `None`, `UMD`, `AMD`, `System`, `ESNext`
      */
     "module": "ES2015",
-    /* Set the language version for emitted JavaScript: `ES3` (default), `ES5`, 
-     * `ES6`/`ES2015` (synonymous), `ES7`/`ES2016`, `ES2017`, `ES2018`, `ES2019`, 
+    /* Set the language version for emitted JavaScript: `ES3` (default), `ES5`,
+     * `ES6`/`ES2015` (synonymous), `ES7`/`ES2016`, `ES2017`, `ES2018`, `ES2019`,
      * `ES2020`, or `ESNext`
      * https://stackoverflow.com/a/42429053/7435656
      */


### PR DESCRIPTION
Coming from one of the lead maintainers of webpack, it's recommended to not bundle libraries: 
- https://github.com/webpack/webpack/issues/8951#issuecomment-617761007
- https://github.com/webpack/webpack/issues/5801#issuecomment-335841698

Since this library is meant to be used by projects, and not browsers or node directly, the best approach is to transpile the typescript to ES6 modules and leave it up to the consumer project to decide how to bundle the output.