### PR TITLE
fix: module not found in TypeScript 4.9.4

### DIFF
--- a/.changeset/weak-birds-trade.md
+++ b/.changeset/weak-birds-trade.md
@@ -1,0 +1,5 @@
+---
+"hazel-ui": patch
+---
+
+fix: types metadata in package.json

--- a/package.json
+++ b/package.json
@@ -5,14 +5,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "import": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
     "./fonts.css": "./dist/fonts.css"
   },
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
### Description

The types field under exports is still not properly supported in a consumer project using TypeScript 4.9.4.
Support might be fixed in TypeScript v5 but for now the fix is to use the "types" field in package.json instead which older versions of TypeScript recognise.

Refer:
- https://stackoverflow.com/questions/58990498/package-json-exports-field-not-working-with-typescript
- https://github.com/microsoft/TypeScript/issues/50794#issuecomment-1253069570
- https://github.com/andrewbranch/example-subpath-exports-ts-compat/tree/main/examples/node_modules/package-json-redirects

### Checklist

- [x] My changes generate no new warnings
- [x] I've done a self-review of this pull request
