### PR TITLE
ci: use rollup for bundling package

### DIFF
--- a/.changeset/cold-schools-give.md
+++ b/.changeset/cold-schools-give.md
@@ -1,0 +1,9 @@
+---
+"hazel-ui": patch
+---
+
+fix: tree shaking
+
+- switch to rollup for bundling the package
+- added sideEffects package.json metadata to enable tree shaking
+- added terser for minifying bundle

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,5 @@
-import { Typography, Color } from "../dist/index.js";
-// import { Typography, Color } from "../src/package/index.js";
+// import { Typography, Color } from "../dist/index.js";
+import { Typography, Color } from "../src/package/index.js";
 
 export function App(): JSX.Element {
   return (

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,6 @@
-// import { Typography, Color } from "../dist";
-import { Typography, Color } from "../src/package/index.js";
+import { Typography } from "../dist/foundation/Typography/Typography.js";
+import { Color } from "../dist/foundation/Color/Color.js";
+// import { Typography, Color } from "../src/package/index.js";
 
 export function App(): JSX.Element {
   return (

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,4 @@
-import { Typography } from "../dist/foundation/Typography/Typography.js";
-import { Color } from "../dist/foundation/Color/Color.js";
+import { Typography, Color } from "../dist/index.js";
 // import { Typography, Color } from "../src/package/index.js";
 
 export function App(): JSX.Element {

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -62,7 +62,7 @@ The below table explains why certain dependencies are required by the project in
 
 | Name | Version  |
 | ---- | -------- |
-| node | v18.12.1 |
+| node | v18.13.0 |
 | npm  | 9.2.0    |
 
 [1]: https://www.npmjs.com/package/@storybook/react

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -22,7 +22,8 @@ The below table explains why certain dependencies are required by the project in
 | @babel/plugin-transform-react-jsx | Required by Storybook to parse jsx    |
 | @changesets/changelog-github      | Adds GitHub metadata to changelog     |
 | @changesets/cli                   | CLI for Changesets                    |
-| @radix-ui/colors                  | color palette for dark mode           |
+| @rollup/plugin-terser             | Minify the npm package                |
+| @rollup/plugin-typescript         | TypeScript support for rollup         |
 | @types/jest                       | Required for `expect()` in tests      |
 | @types/node                       | Required by [@storybook/react][1]     |
 | @typescript-eslint/eslint-plugin  | typescript-eslint core                |
@@ -49,6 +50,7 @@ The below table explains why certain dependencies are required by the project in
 | prettier                          | Code formatter                        |
 | react                             | React core                            |
 | react-dom                         | React core                            |
+| rollup                            | npm package bundler                   |
 | style-loader                      | Support importing css files           |
 | tailwindcss                       | styling utility                       |
 | ts-loader                         | Required by webpack to parse jsx      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@babel/plugin-transform-react-jsx": "^7.14.3",
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.0",
+        "@rollup/plugin-typescript": "^11.0.0",
         "@storybook/addon-essentials": "^7.0.0-beta.20",
         "@storybook/react": "^7.0.0-beta.20",
         "@storybook/react-webpack5": "^7.0.0-beta.20",
@@ -62,6 +63,7 @@
         "prettier": "^2.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "rollup": "^3.10.0",
         "storybook": "^7.0.0-beta.20",
         "style-loader": "^2.0.0",
         "ts-loader": "^9.4.2",
@@ -5368,6 +5370,60 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
       }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -14540,6 +14596,12 @@
       "engines": {
         "node": ">=8.3.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -24429,6 +24491,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.10.0.tgz",
+      "integrity": "sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -31764,6 +31842,35 @@
         "@radix-ui/react-use-callback-ref": "0.0.5"
       }
     },
+    "@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+          "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+          "dev": true
+        }
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -38635,6 +38742,12 @@
         "@babel/types": "^7.2.0",
         "c8": "^7.6.0"
       }
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -46180,6 +46293,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.10.0.tgz",
+      "integrity": "sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@babel/plugin-transform-react-jsx": "^7.14.3",
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.0",
+        "@rollup/plugin-terser": "^0.3.0",
         "@rollup/plugin-typescript": "^11.0.0",
         "@storybook/addon-essentials": "^7.0.0-beta.20",
         "@storybook/react": "^7.0.0-beta.20",
@@ -5369,6 +5370,28 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.3.0.tgz",
+      "integrity": "sha512-mYTkNW9KjOscS/3QWU5LfOKsR3/fAAVDaqcAe2TZ7ng6pN46f+C7FOZbITuIW/neA+PhcjoKl7yMyB3XcmA4gw==",
+      "dev": true,
+      "dependencies": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x || ^3.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -16233,18 +16256,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/html-minifier-terser/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/html-minifier-terser/node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -16253,30 +16264,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/html-minifier-terser/node_modules/terser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
     },
     "node_modules/html-tags": {
       "version": "3.2.0",
@@ -25091,6 +25078,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
+      "dev": true
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -26113,6 +26106,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/terser": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
@@ -26145,18 +26156,6 @@
         "uglify-js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/has-flag": {
@@ -26215,22 +26214,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
       "bin": {
-        "terser": "bin/terser"
+        "acorn": "bin/acorn"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/test-exclude": {
@@ -31840,6 +31833,17 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "0.0.5"
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.3.0.tgz",
+      "integrity": "sha512-mYTkNW9KjOscS/3QWU5LfOKsR3/fAAVDaqcAe2TZ7ng6pN46f+C7FOZbITuIW/neA+PhcjoKl7yMyB3XcmA4gw==",
+      "dev": true,
+      "requires": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
       }
     },
     "@rollup/plugin-typescript": {
@@ -40043,37 +40047,11 @@
         "terser": "^5.10.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-          "dev": true
-        },
         "commander": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
-        },
-        "terser": {
-          "version": "5.16.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-          "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.3",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -46791,6 +46769,12 @@
         }
       }
     },
+    "smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -47590,6 +47574,26 @@
         "supports-hyperlinks": "^2.0.0"
       }
     },
+    "terser": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+          "dev": true
+        }
+      }
+    },
     "terser-webpack-plugin": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
@@ -47603,12 +47607,6 @@
         "terser": "^5.14.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -47644,18 +47642,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "terser": {
-          "version": "5.16.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-          "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.2",
-            "acorn": "^8.5.0",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "change:add": "changeset add",
     "prepublishOnly": "npm run build:package",
     "predeploy": "npm run build-storybook",
-    "deploy": "gh-pages -d ./dist-storybook"
+    "deploy": "gh-pages -d ./dist-storybook",
+    "build:lib": "rollup --config rollup.config.ts --configPlugin typescript"
   },
   "dependencies": {
     "@radix-ui/react-tabs": "^0.0.13",
@@ -60,6 +61,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.3",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.0",
+    "@rollup/plugin-typescript": "^11.0.0",
     "@storybook/addon-essentials": "^7.0.0-beta.20",
     "@storybook/react": "^7.0.0-beta.20",
     "@storybook/react-webpack5": "^7.0.0-beta.20",
@@ -98,6 +100,7 @@
     "prettier": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rollup": "^3.10.0",
     "storybook": "^7.0.0-beta.20",
     "style-loader": "^2.0.0",
     "ts-loader": "^9.4.2",

--- a/package.json
+++ b/package.json
@@ -34,16 +34,14 @@
     "build": "webpack --config webpack.prod.mjs",
     "start": "npx http-server ./build -o",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "build:compile": "rm -rf dist && mkdir dist && cd src/package && tsc",
+    "build:compile": "rollup --config rollup.config.ts --configPlugin typescript",
     "build:static": "copyfiles -u 3 \"src/package/static/**/*\" dist",
-    "build:package:dev": "npm run build:compile && npm run build:static",
-    "build:package": "npm run build:compile",
+    "build:package": "rm -rf dist && npm run build:compile",
     "postbuild:package": "npm run build:static",
     "change:add": "changeset add",
     "prepublishOnly": "npm run build:package",
     "predeploy": "npm run build-storybook",
-    "deploy": "gh-pages -d ./dist-storybook",
-    "build:lib": "rollup --config rollup.config.ts --configPlugin typescript"
+    "deploy": "gh-pages -d ./dist-storybook"
   },
   "dependencies": {
     "@radix-ui/react-tabs": "^0.0.13",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.3",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.0",
+    "@rollup/plugin-terser": "^0.3.0",
     "@rollup/plugin-typescript": "^11.0.0",
     "@storybook/addon-essentials": "^7.0.0-beta.20",
     "@storybook/react": "^7.0.0-beta.20",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "./fonts.css": "./dist/fonts.css"
   },
   "types": "./dist/index.d.ts",
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "dist/"
   ],

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,3 +1,4 @@
+import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import glob from "glob";
 import path from "path";
@@ -27,5 +28,5 @@ export default defineConfig({
     hoistTransitiveImports: false, // don't add additional imports to entry files
   },
 
-  plugins: [typescript({ tsconfig: "src/package/tsconfig.json" })],
+  plugins: [typescript({ tsconfig: "src/package/tsconfig.json" }), terser()],
 });

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,7 +5,15 @@ import path from "path";
 import { defineConfig } from "rollup";
 import { fileURLToPath } from "url";
 
+import pkg from "./package.json" assert { type: "json" };
+
 export default defineConfig({
+  // https://rollupjs.org/guide/en/#importing-packagejson
+  external: [
+    ...Object.keys(pkg.dependencies),
+    ...Object.keys(pkg.peerDependencies),
+    "react/jsx-runtime",
+  ],
   input: Object.fromEntries(
     glob.sync("src/package/**/!(*.stories|*.test).@(ts|tsx)").map((file) => [
       // This remove `src/package` as well as the file extension from each file
@@ -22,7 +30,6 @@ export default defineConfig({
 
   output: {
     dir: "dist",
-    format: "es",
     generatedCode: "es2015",
     hoistTransitiveImports: false, // don't add additional imports to entry files
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -27,5 +27,8 @@ export default defineConfig({
     hoistTransitiveImports: false, // don't add additional imports to entry files
   },
 
-  plugins: [typescript({ tsconfig: "src/package/tsconfig.json" }), terser()],
+  plugins: [
+    typescript({ tsconfig: "src/package/tsconfig.json" }),
+    terser({ ecma: 2020 }), // https://github.com/terser/terser#compress-options
+  ],
 });

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     ...Object.keys(pkg.peerDependencies),
     "react/jsx-runtime",
   ],
+  // https://rollupjs.org/guide/en/#input
   input: Object.fromEntries(
     glob.sync("src/package/**/!(*.stories|*.test).@(ts|tsx)").map((file) => [
       // This remove `src/package` as well as the file extension from each file

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,34 @@
+import typescript from "@rollup/plugin-typescript";
+import { defineConfig } from "rollup";
+
+import glob from "glob";
+import path from "path";
+import { fileURLToPath } from "url";
+
+export default defineConfig({
+  // TODO: Consider turning every component to an export and removing preserveModules
+  // https://rollupjs.org/guide/en/#input
+  input: Object.fromEntries(
+    glob.sync("src/package/**/!(*.stories|*.test).@(ts|tsx)").map((file) => [
+      // This remove `src/package` as well as the file extension from each file
+      // e.g. src/package/nested/foo.ts becomes nested/foo
+      path.relative(
+        "src/package",
+        file.slice(0, file.length - path.extname(file).length)
+      ),
+      // This expands the relative paths to absolute paths
+      // e.g. src/nested/foo becomes /project/src/nested/foo.ts
+      fileURLToPath(new URL(file, import.meta.url)),
+    ])
+  ),
+
+  // TODO: Consider terser for minifying output to reduce package size
+  output: {
+    dir: "dist-lib",
+    format: "es",
+    generatedCode: "es2015",
+    preserveModules: true,
+  },
+
+  plugins: [typescript({ tsconfig: "src/package/tsconfig.json" })],
+});

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,13 +1,10 @@
 import typescript from "@rollup/plugin-typescript";
-import { defineConfig } from "rollup";
-
 import glob from "glob";
 import path from "path";
+import { defineConfig } from "rollup";
 import { fileURLToPath } from "url";
 
 export default defineConfig({
-  // TODO: Consider turning every component to an export and removing preserveModules
-  // https://rollupjs.org/guide/en/#input
   input: Object.fromEntries(
     glob.sync("src/package/**/!(*.stories|*.test).@(ts|tsx)").map((file) => [
       // This remove `src/package` as well as the file extension from each file
@@ -24,10 +21,10 @@ export default defineConfig({
 
   // TODO: Consider terser for minifying output to reduce package size
   output: {
-    dir: "dist-lib",
+    dir: "dist",
     format: "es",
     generatedCode: "es2015",
-    preserveModules: true,
+    hoistTransitiveImports: false, // don't add additional imports to entry files
   },
 
   plugins: [typescript({ tsconfig: "src/package/tsconfig.json" })],

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
     ])
   ),
 
-  // TODO: Consider terser for minifying output to reduce package size
   output: {
     dir: "dist",
     format: "es",

--- a/src/package/components/Card/stories/Card.stories.tsx
+++ b/src/package/components/Card/stories/Card.stories.tsx
@@ -1,9 +1,7 @@
-import { Color } from "../../../foundation/Color/Color.js";
 import { Typography } from "../../../foundation/Typography/Typography.js";
 import { Card } from "../Card.js";
 
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
 
 const meta: Meta<typeof Card> = {
   title: "Components/Card",

--- a/src/package/components/Search/styles/placeholderStyles.ts
+++ b/src/package/components/Search/styles/placeholderStyles.ts
@@ -8,7 +8,7 @@ import type { CSSProperties } from "react";
 
 export const placeholderStyles: StylesConfigFunction<
   PlaceholderProps<{}, boolean>
-> = (base: CSSProperties, state: any) => ({
+> = (base: CSSProperties, _state: any) => ({
   ...base,
   fontFamily: Theme.font.sansSerif,
 });

--- a/src/package/foundation/MediaQuery/stories/examples/EgTouch.tsx
+++ b/src/package/foundation/MediaQuery/stories/examples/EgTouch.tsx
@@ -1,5 +1,0 @@
-type EgTouchProps = {};
-
-export function EgTouch(props: EgTouchProps) {
-  return <></>;
-}

--- a/src/package/tsconfig.json
+++ b/src/package/tsconfig.json
@@ -24,9 +24,8 @@
     // Linter Checks
     "noFallthroughCasesInSwitch": true, // disable fallthrough of cases in 'switch'
     "noImplicitReturns": true, // make sure functions return a value
-    // "noPropertyAccessFromIndexSignature": true, // consistency for accessing object fields
-    // "noUnusedLocals": true, // no unused local variables
-    // "noUnusedParameters": true, // no unused function parameters
+    "noUnusedLocals": true, // no unused local variables
+    "noUnusedParameters": true, // no unused function parameters
 
     // Advanced
     "allowUnreachableCode": false, // raise errors for unreachable code

--- a/src/package/types.d.ts
+++ b/src/package/types.d.ts
@@ -1,5 +1,0 @@
-declare module "@bbc/gel-foundations/scripts";
-declare module "@bbc/gel-foundations/typography";
-declare module "*.md";
-declare module "*.mdx";
-declare module "*.svg";


### PR DESCRIPTION
### Description

This changes the bundling strategy of hazel-ui from a simple `tsc` to `rollup`. This has several benefits:
- Terser plugin helps reduce the size of the package
- Flexibility to ship static styles by generating them at build time (e.g. with vanilla-extract)

#### Differences in the bundle:
- Files that contained only types are now empty instead of containing an empty export `export {}`

#### Package size (not including static styles):

| State | Size |
|-|-|
| Before (tsc) | 106 KB |
| After (rollup without terser) | 104 KB |
| After (rollup with terser) | 89 KB |

#### Other improvements:
- Added [sideEffects][1] field to package.json so consumers can tree shake the library
- Stricter type check rules

### Checklist

- [x] My changes generate no new warnings
- [x] I've done a self-review of this pull request

[1]: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
