### PR TITLE
fix: anchor default border

### DIFF
--- a/.changeset/plenty-snails-grab.md
+++ b/.changeset/plenty-snails-grab.md
@@ -1,0 +1,5 @@
+---
+"hazel-ui": patch
+---
+
+fix: anchor default border style

--- a/src/package/components/Anchor/Anchor.css.ts
+++ b/src/package/components/Anchor/Anchor.css.ts
@@ -6,6 +6,7 @@ export const anchor = style([
   transitionAll,
   {
     textDecoration: "none",
+    borderBottomStyle: "none",
 
     ":hover": {
       cursor: "pointer",


### PR DESCRIPTION
### Description

Next.js applications are seeing the border coming up without hovering on Anchor. This should fix it.

### Checklist

- [ ] My changes generate no new warnings
- [ ] I've done a self-review of this pull request
