### PR TITLE
feat: support deep imports

### DIFF
--- a/.changeset/lucky-lions-bake.md
+++ b/.changeset/lucky-lions-bake.md
@@ -11,3 +11,4 @@ feat: add support for deep importing components individually
 - add individual exports for each component
 - add Space tokens based on Tailwind
 - changed Typography tokens based on feedback
+- fix table render warning in MediaQuery story

--- a/.changeset/lucky-lions-bake.md
+++ b/.changeset/lucky-lions-bake.md
@@ -1,0 +1,13 @@
+---
+"hazel-ui": patch
+---
+
+feat: add support for deep importing components individually
+
+- add eslint rule import/no-extreneous-dependencies
+- remove redundant override for stories files
+- add wildcart exports config to root package.json
+- enable beautify option in terser for better debugging
+- add individual exports for each component
+- add Space tokens based on Tailwind
+- changed Typography tokens based on feedback

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -135,6 +135,12 @@ module.exports = {
      *****************************************************************/
 
     /**
+     * Don't allow importing packages from node_modules that are not a direct dependency
+     * @see https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md
+     */
+    "import/no-extraneous-dependencies": "error",
+
+    /**
      * Group imports by type for better readability: external, absolute, relative
      * @see https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
      */
@@ -232,17 +238,6 @@ module.exports = {
          * @see https://storybook.js.org/docs/react/api/csf#default-export
          */
         "import/no-default-export": "off",
-        /**
-         * Allow importing devDependencies in stories.
-         * @see https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js
-         */
-        "import/no-extraneous-dependencies": [
-          "error",
-          {
-            devDependencies: true,
-            optionalDependencies: false,
-          },
-        ],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
       "import": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
-    "./fonts.css": "./dist/fonts.css"
+    "./fonts.css": "./dist/fonts.css",
+    "./*": {
+      "import": "./dist/exports/*.js",
+      "types": "./dist/exports/*.d.ts"
+    }
   },
   "types": "./dist/index.d.ts",
   "sideEffects": [

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -39,6 +39,6 @@ export default defineConfig({
   plugins: [
     typescript({ tsconfig: "src/package/tsconfig.json" }),
     vanillaExtractPlugin({ identifiers: "short" }),
-    terser({ ecma: 2020 }), // https://github.com/terser/terser#compress-options
+    terser({ ecma: 2020, format: { beautify: true, indent_level: 1 } }), // https://github.com/terser/terser#compress-options
   ],
 });

--- a/src/package/Typography.ts
+++ b/src/package/Typography.ts
@@ -1,0 +1,2 @@
+export { Typography } from "./foundation/Typography/Typography.js";
+export type { TypographyProps } from "./foundation/Typography/Typography.js";

--- a/src/package/Typography.ts
+++ b/src/package/Typography.ts
@@ -1,2 +1,0 @@
-export { Typography } from "./foundation/Typography/Typography.js";
-export type { TypographyProps } from "./foundation/Typography/Typography.js";

--- a/src/package/exports/Anchor.ts
+++ b/src/package/exports/Anchor.ts
@@ -1,0 +1,2 @@
+export { Anchor } from "../components/Anchor/Anchor.js";
+export type { AnchorProps } from "../components/Anchor/Anchor.js";

--- a/src/package/exports/Badge.ts
+++ b/src/package/exports/Badge.ts
@@ -1,0 +1,2 @@
+export { Badge } from "../components/Badge/Badge.js";
+export type { BadgeProps } from "../components/Badge/Badge.js";

--- a/src/package/exports/Button.ts
+++ b/src/package/exports/Button.ts
@@ -1,0 +1,2 @@
+export { Button } from "../components/Button/Button.js";
+export type { ButtonProps } from "../components/Button/Button.js";

--- a/src/package/exports/Card.ts
+++ b/src/package/exports/Card.ts
@@ -1,0 +1,2 @@
+export { Card } from "../components/Card/Card.js";
+export type { CardProps } from "../components/Card/Card.js";

--- a/src/package/exports/Color.ts
+++ b/src/package/exports/Color.ts
@@ -1,0 +1,1 @@
+export { Color } from "../foundation/Color/Color.js";

--- a/src/package/exports/Divider.ts
+++ b/src/package/exports/Divider.ts
@@ -1,0 +1,2 @@
+export { Divider } from "../components/Divider/Divider.js";
+export type { DividerProps } from "../components/Divider/Divider.js";

--- a/src/package/exports/Icon.ts
+++ b/src/package/exports/Icon.ts
@@ -1,0 +1,1 @@
+export { Icon } from "../foundation/Icon/Icon.js";

--- a/src/package/exports/MediaQuery.ts
+++ b/src/package/exports/MediaQuery.ts
@@ -1,0 +1,1 @@
+export { MediaQuery } from "../foundation/MediaQuery/MediaQuery.js";

--- a/src/package/exports/Search.ts
+++ b/src/package/exports/Search.ts
@@ -1,0 +1,6 @@
+export { Search } from "../components/Search/Search.js";
+export type { SearchProps } from "../components/Search/Search.js";
+export type {
+  SearchOptionType,
+  SearchValueType,
+} from "../components/Search/types.js";

--- a/src/package/exports/Shadow.ts
+++ b/src/package/exports/Shadow.ts
@@ -1,0 +1,1 @@
+export { Shadow } from "../foundation/Shadow/Shadow.js";

--- a/src/package/exports/Slider.ts
+++ b/src/package/exports/Slider.ts
@@ -1,0 +1,2 @@
+export { Slider } from "../components/Slider/Slider.js";
+export type { SliderProps } from "../components/Slider/Slider.js";

--- a/src/package/exports/Table.ts
+++ b/src/package/exports/Table.ts
@@ -1,0 +1,2 @@
+export { Table } from "../components/Table/Table.js";
+export type { TableProps } from "../components/Table/Table.js";

--- a/src/package/exports/Theme.ts
+++ b/src/package/exports/Theme.ts
@@ -1,0 +1,1 @@
+export { Theme } from "../foundation/Theme/Theme.js";

--- a/src/package/exports/Toast.ts
+++ b/src/package/exports/Toast.ts
@@ -1,0 +1,1 @@
+export { Toast, showToast } from "../components/Toast/Toast.js";

--- a/src/package/exports/Tooltip.ts
+++ b/src/package/exports/Tooltip.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from "../components/Tooltip/Tooltip.js";
+export type { TooltipProps } from "../components/Tooltip/Tooltip.js";

--- a/src/package/exports/Typography.ts
+++ b/src/package/exports/Typography.ts
@@ -1,0 +1,2 @@
+export { Typography } from "../foundation/Typography/Typography.js";
+export type { TypographyProps } from "../foundation/Typography/Typography.js";

--- a/src/package/foundation/MediaQuery/stories/MediaQuery.stories.mdx
+++ b/src/package/foundation/MediaQuery/stories/MediaQuery.stories.mdx
@@ -12,6 +12,9 @@ The breakpoints have been taken from [Material M3][1].
 
 ## Breakpoints
 
+{/* Why these brackets: https://github.com/mdx-js/mdx/issues/2000#issuecomment-1280603924 */}
+{
+
 <table>
   <thead>
     <tr>
@@ -30,6 +33,7 @@ The breakpoints have been taken from [Material M3][1].
     </tr>
   </tbody>
 </table>
+}
 
 ## Example
 

--- a/src/package/foundation/Space/Space.ts
+++ b/src/package/foundation/Space/Space.ts
@@ -1,0 +1,7 @@
+export const Space = {
+  /** 6px */
+  "1.5": "0.375rem",
+
+  /** 16px */
+  "4": "1rem",
+};

--- a/src/package/foundation/Typography/Typography.css.ts
+++ b/src/package/foundation/Typography/Typography.css.ts
@@ -7,7 +7,7 @@ const base = style({
 });
 
 /**
- * Variants are taken from Material M3
+ * Variants are inspired by Material M3
  * @see https://m3.material.io/styles/typography/type-scale-tokens
  */
 export const variants = styleVariants({
@@ -28,8 +28,8 @@ export const variants = styleVariants({
         },
 
         [MediaQuery.minWidth.desktop]: {
-          lineHeight: "4rem" /** 64px */,
-          fontSize: "3.5625rem" /** 57px */,
+          lineHeight: "3.8rem" /** 61px */, // modified
+          fontSize: "3rem" /** 48px */, // modified
           letterSpacing: 0 /* letterSpacing = (tracking / size in px) */,
           fontWeight: 400,
         },
@@ -118,19 +118,12 @@ export const variants = styleVariants({
   body: [
     base,
     {
-      lineHeight: "1rem" /** 16px */,
-      fontSize: "0.75rem" /** 12px */,
-      letterSpacing: "0.033333rem" /** tracking: 0.4px */,
+      lineHeight: "1.25rem" /** 20px */,
+      fontSize: "0.875rem" /** 14px */,
+      letterSpacing: "0.017857rem" /** tracking: 0.25px */,
       fontWeight: 400,
 
       "@media": {
-        [MediaQuery.minWidth.tablet]: {
-          lineHeight: "1.25rem" /** 20px */,
-          fontSize: "0.875rem" /** 14px */,
-          letterSpacing: "0.017857rem" /** tracking: 0.25px */,
-          fontWeight: 400,
-        },
-
         [MediaQuery.minWidth.desktop]: {
           lineHeight: "1.5rem" /** 24px */,
           fontSize: "1rem" /** 16px */,

--- a/src/package/foundation/Typography/Typography.css.ts
+++ b/src/package/foundation/Typography/Typography.css.ts
@@ -118,9 +118,9 @@ export const variants = styleVariants({
   body: [
     base,
     {
-      lineHeight: "1.25rem" /** 20px */,
-      fontSize: "0.875rem" /** 14px */,
-      letterSpacing: "0.017857rem" /** tracking: 0.25px */,
+      lineHeight: "1.25rem" /** 20px */, // modified
+      fontSize: "0.875rem" /** 14px */, // modified
+      letterSpacing: "0.017857rem" /** tracking: 0.25px */, // modified
       fontWeight: 400,
 
       "@media": {


### PR DESCRIPTION
### Description

Imports from hazel-ui are throwing errors in server components because Next.js has issues with tree shaking imports from barrel files. The issue is not in hazel-ui but we can provide a workaround for the issue by allowing the consumers to directly import individual components from a sub-path instead of from the root package.

More information: https://github.com/vercel/next.js/issues/12557#issuecomment-1427088366

So, a root level import like the one below throws an error in Next.js because the Search components has a `useState` hook not compatible with server components.

```tsx
import { Typography } from "hazel-ui";
```

This pull request enables replacing the above code with a deep import:

```tsx
import { Typography } from "hazel-ui/Typography";
```

This will work in server components because now Next.js doesn't have to tree shake anything. The sub-path only exports a single component.

### Checklist

- [x] My changes generate no new warnings
- [ ] I've done a self-review of this pull request
