### PR TITLE
fix: order of types in exports

### DIFF
--- a/.changeset/ten-melons-ring.md
+++ b/.changeset/ten-melons-ring.md
@@ -1,0 +1,5 @@
+---
+"hazel-ui": patch
+---
+
+fix: order of types in exports

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "./styles.css": "./dist/styles.css",
     "./fonts.css": "./dist/fonts.css",
     "./*": {
-      "import": "./dist/exports/*.js",
-      "types": "./dist/exports/*.d.ts"
+      "types": "./dist/exports/*.d.ts",
+      "import": "./dist/exports/*.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/src/package/foundation/Typography/Typography.css.ts
+++ b/src/package/foundation/Typography/Typography.css.ts
@@ -1,4 +1,5 @@
 import { style, styleVariants } from "@vanilla-extract/css";
+
 import { MediaQuery } from "../MediaQuery/MediaQuery.js";
 import { Theme } from "../Theme/Theme.js";
 


### PR DESCRIPTION
### Description

TypeScript team recommends that the types field should be defined before anything else in exports.
- https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
- https://github.com/microsoft/TypeScript/issues/50762

### Checklist

- [x] My changes generate no new warnings
- [x] I've done a self-review of this pull request
