### PR TITLE
fix: types exports for node10

### DIFF
--- a/.changeset/lucky-books-sparkle.md
+++ b/.changeset/lucky-books-sparkle.md
@@ -1,0 +1,5 @@
+---
+"hazel-ui": patch
+---
+
+fix: types exports for node10

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
       "default": "./dist/index.js"
     },
     "./styles.css": {
-      "types": "./dist/css.d.ts",
+      "types": "./dist/styles.css.d.ts",
       "default": "./dist/styles.css"
     },
     "./fonts.css": {
-      "types": "./dist/css.d.ts",
+      "types": "./dist/fonts.css.d.ts",
       "default": "./dist/fonts.css"
     },
     "./*": {
@@ -21,6 +21,7 @@
       "default": "./dist/exports/*.js"
     }
   },
+  "types": "./dist/index.d.ts",
   "sideEffects": [
     "*.css"
   ],

--- a/src/static/fonts.css.d.ts
+++ b/src/static/fonts.css.d.ts
@@ -1,0 +1,1 @@
+declare module "fonts.css";

--- a/src/static/styles.css.d.ts
+++ b/src/static/styles.css.d.ts
@@ -1,2 +1,1 @@
-declare module "fonts.css";
 declare module "styles.css";


### PR DESCRIPTION
### Description

Fixes types exports for node10 as reported by https://arethetypeswrong.github.io/

### Checklist

- [x] My changes generate no new warnings
- [x] I've done a self-review of this pull request
