### PR TITLE
chore: upgrade to typescript v5

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -3,11 +3,8 @@ name: developer
 description: Default agent for hazel-ui code changes.
 ---
 
-## Project Context
-
-Stack: React 18, TypeScript 4.9, Storybook 8 (Vite), Rollup 3, pnpm 11, Node 22
+Stack: React 18, TypeScript 5.8, Storybook 8 (Vite), pnpm 11, Node 22
 Styling: Vanilla Extract (`.css.ts`) + styled-components (migrating to CSS Modules in v0.5.0)
-Package output: ES modules in `dist/`, per-component exports via `src/package/exports/`
 Build gates: `pnpm build`, `pnpm build:package`, `pnpm storybook`
 
 ## Conventions
@@ -15,6 +12,14 @@ Build gates: `pnpm build`, `pnpm build:package`, `pnpm storybook`
 - `import type` for type-only imports
 - Node built-ins (`node:fs`, `node:path`) over third-party equivalents
 - New external dependencies must be listed in `docs/dependencies.md`
+
+## GitHub
+
+`gh pr edit` silently fails on this repo. Use the REST API:
+
+```bash
+gh api repos/hazel-ui/hazel-ui/pulls/{number} --method PATCH --field body="..." --jq '.body'
+```
 
 ## Constraints
 

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,0 +1,24 @@
+name: Package Size
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.1
+
+      - name: Compare package size
+        uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: "./dist/**/*.{js,css}"
+          build-script: "build:package"

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,4 +1,4 @@
-name: Package Size
+name: package
 
 on:
   pull_request:

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![pull-requests](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![code-style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io/)
 [![airbnb-style](https://img.shields.io/badge/eslint-airbnb-4B32C3.svg)](https://github.com/airbnb/javascript)
-[![license](https://img.shields.io/github/license/sourcerer-io/hall-of-fame.svg?colorB=ff0000)](LICENSE)
+[![license](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
 [![typescript](https://badgen.net/badge/Built%20With/TypeScript/blue)](https://www.typescriptlang.org/)
 [![tested-with](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://jestjs.io/)

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -82,7 +82,7 @@ The below table explains why certain dependencies are required by the project in
 | Name | Version  |
 | ---- | -------- |
 | node | v22.16.0 |
-| pnpm | 10.12.3  |
+| pnpm | 11.1.1   |
 
 [1]: https://www.npmjs.com/package/@storybook/react
 [2]: https://www.npmjs.com/package/react-scripts

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "build:package": "rm -rf dist && pnpm build:compile",
     "postbuild:package": "pnpm build:static",
     "change:add": "changeset add",
-    "prepublishOnly": "npm run build:package",
-    "predeploy": "npm run build-storybook",
+    "prepublishOnly": "pnpm build:package",
+    "predeploy": "pnpm build-storybook",
     "deploy": "gh-pages -d ./dist-storybook"
   },
   "dependencies": {
@@ -127,7 +127,7 @@
     "style-loader": "2.0.0",
     "ts-loader": "9.4.2",
     "tslib": "2.8.1",
-    "typescript": "4.9.4",
+    "typescript": "5.8.3",
     "vite": "6.4.2",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 0.3.0(rollup@3.10.0)
       '@rollup/plugin-typescript':
         specifier: 11.0.0
-        version: 11.0.0(rollup@3.10.0)(tslib@2.8.1)(typescript@4.9.4)
+        version: 11.0.0(rollup@3.10.0)(tslib@2.8.1)(typescript@5.8.3)
       '@storybook/addon-docs':
         specifier: 8.6.18
         version: 8.6.18(@types/react@18.0.26)(storybook@8.6.18(prettier@2.3.2))
@@ -62,10 +62,10 @@ importers:
         version: 8.6.18(@types/react@18.0.26)(storybook@8.6.18(prettier@2.3.2))
       '@storybook/react':
         specifier: 8.6.18
-        version: 8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.18(prettier@2.3.2))(typescript@4.9.4)
+        version: 8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.18(prettier@2.3.2))(typescript@5.8.3)
       '@storybook/react-vite':
         specifier: 8.6.18
-        version: 8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.10.0)(storybook@8.6.18(prettier@2.3.2))(typescript@4.9.4)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.10.0)(storybook@8.6.18(prettier@2.3.2))(typescript@5.8.3)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))
       '@testing-library/jest-dom':
         specifier: 5.11.9
         version: 5.11.9
@@ -98,10 +98,10 @@ importers:
         version: 5.1.10
       '@typescript-eslint/eslint-plugin':
         specifier: 5.47.1
-        version: 5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(typescript@4.9.4)
+        version: 5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: 5.47.1
-        version: 5.47.1(eslint@8.31.0)(typescript@4.9.4)
+        version: 5.47.1(eslint@8.31.0)(typescript@5.8.3)
       '@vanilla-extract/css':
         specifier: 1.20.1
         version: 1.20.1(babel-plugin-macros@3.1.0)
@@ -140,10 +140,10 @@ importers:
         version: 3.2.0(eslint@8.31.0)
       eslint-plugin-import:
         specifier: 2.26.0
-        version: 2.26.0(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)
+        version: 2.26.0(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)
       eslint-plugin-jest:
         specifier: 27.2.0
-        version: 27.2.0(@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(jest@27.0.6)(typescript@4.9.4)
+        version: 27.2.0(@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(jest@27.0.6)(typescript@5.8.3)
       eslint-plugin-jest-formatting:
         specifier: 3.0.0
         version: 3.0.0(eslint@8.31.0)
@@ -158,7 +158,7 @@ importers:
         version: 4.2.0(eslint@8.31.0)
       eslint-plugin-storybook:
         specifier: 0.6.8
-        version: 0.6.8(eslint@8.31.0)(typescript@4.9.4)
+        version: 0.6.8(eslint@8.31.0)(typescript@5.8.3)
       eslint-plugin-unicorn:
         specifier: 45.0.2
         version: 45.0.2(eslint@8.31.0)
@@ -194,13 +194,13 @@ importers:
         version: 2.0.0(webpack@5.75.0)
       ts-loader:
         specifier: 9.4.2
-        version: 9.4.2(typescript@4.9.4)(webpack@5.75.0)
+        version: 9.4.2(typescript@5.8.3)(webpack@5.75.0)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
       typescript:
-        specifier: 4.9.4
-        version: 4.9.4
+        specifier: 5.8.3
+        version: 5.8.3
       vite:
         specifier: 6.4.2
         version: 6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1)
@@ -5701,9 +5701,9 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript@4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.3:
@@ -7174,14 +7174,14 @@ snapshots:
       '@types/yargs': 16.0.11
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@4.9.4)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))':
     dependencies:
       glob: 10.5.0
       magic-string: 0.27.0
-      react-docgen-typescript: 2.4.0(typescript@4.9.4)
+      react-docgen-typescript: 2.4.0(typescript@5.8.3)
       vite: 6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7398,11 +7398,11 @@ snapshots:
     optionalDependencies:
       rollup: 3.10.0
 
-  '@rollup/plugin-typescript@11.0.0(rollup@3.10.0)(tslib@2.8.1)(typescript@4.9.4)':
+  '@rollup/plugin-typescript@11.0.0(rollup@3.10.0)(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@3.10.0)
       resolve: 1.22.12
-      typescript: 4.9.4
+      typescript: 5.8.3
     optionalDependencies:
       rollup: 3.10.0
       tslib: 2.8.1
@@ -7648,12 +7648,12 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 8.6.18(prettier@2.3.2)
 
-  '@storybook/react-vite@8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.10.0)(storybook@8.6.18(prettier@2.3.2))(typescript@4.9.4)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))':
+  '@storybook/react-vite@8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.10.0)(storybook@8.6.18(prettier@2.3.2))(typescript@5.8.3)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@4.9.4)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))
       '@rollup/pluginutils': 5.3.0(rollup@3.10.0)
       '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@2.3.2))(vite@6.4.2(@types/node@14.14.27)(lightningcss@1.32.0)(terser@5.46.1))
-      '@storybook/react': 8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.18(prettier@2.3.2))(typescript@4.9.4)
+      '@storybook/react': 8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.18(prettier@2.3.2))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 18.2.0
@@ -7668,7 +7668,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.18(prettier@2.3.2))(typescript@4.9.4)':
+  '@storybook/react@8.6.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.6.18(prettier@2.3.2))(typescript@5.8.3)':
     dependencies:
       '@storybook/components': 8.6.18(storybook@8.6.18(prettier@2.3.2))
       '@storybook/global': 5.0.0
@@ -7680,7 +7680,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 8.6.18(prettier@2.3.2)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
 
   '@storybook/theming@8.6.18(storybook@8.6.18(prettier@2.3.2))':
     dependencies:
@@ -8026,33 +8026,33 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(typescript@4.9.4)':
+  '@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/parser': 5.47.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.47.1(eslint@8.31.0)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 5.47.1
-      '@typescript-eslint/type-utils': 5.47.1(eslint@8.31.0)(typescript@4.9.4)
-      '@typescript-eslint/utils': 5.47.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/type-utils': 5.47.1(eslint@8.31.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 5.47.1(eslint@8.31.0)(typescript@5.8.3)
       debug: 4.4.3
       eslint: 8.31.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4)':
+  '@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.47.1
       '@typescript-eslint/types': 5.47.1
-      '@typescript-eslint/typescript-estree': 5.47.1(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.47.1(typescript@5.8.3)
       debug: 4.4.3
       eslint: 8.31.0
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8066,15 +8066,15 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.47.1(eslint@8.31.0)(typescript@4.9.4)':
+  '@typescript-eslint/type-utils@5.47.1(eslint@8.31.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.47.1(typescript@4.9.4)
-      '@typescript-eslint/utils': 5.47.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.47.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 5.47.1(eslint@8.31.0)(typescript@5.8.3)
       debug: 4.4.3
       eslint: 8.31.0
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8082,7 +8082,7 @@ snapshots:
 
   '@typescript-eslint/types@5.62.0': {}
 
-  '@typescript-eslint/typescript-estree@5.47.1(typescript@4.9.4)':
+  '@typescript-eslint/typescript-estree@5.47.1(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 5.47.1
       '@typescript-eslint/visitor-keys': 5.47.1
@@ -8090,13 +8090,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.4)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -8104,19 +8104,19 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@4.9.4)
+      tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.47.1(eslint@8.31.0)(typescript@4.9.4)':
+  '@typescript-eslint/utils@5.47.1(eslint@8.31.0)(typescript@5.8.3)':
     dependencies:
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.47.1
       '@typescript-eslint/types': 5.47.1
-      '@typescript-eslint/typescript-estree': 5.47.1(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.47.1(typescript@5.8.3)
       eslint: 8.31.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.31.0)
@@ -8125,14 +8125,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.31.0)(typescript@4.9.4)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.31.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.31.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
       eslint: 8.31.0
       eslint-scope: 5.1.1
       semver: 7.7.4
@@ -9466,11 +9466,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.10)(eslint@8.31.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint@8.31.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.47.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.47.1(eslint@8.31.0)(typescript@5.8.3)
       eslint: 8.31.0
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -9482,7 +9482,7 @@ snapshots:
       eslint: 8.31.0
       ignore: 5.3.2
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0):
     dependencies:
       array-includes: 3.1.9
       array.prototype.flat: 1.3.3
@@ -9490,7 +9490,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.31.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.10)(eslint@8.31.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint@8.31.0)
       has: 1.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9499,7 +9499,7 @@ snapshots:
       resolve: 1.22.12
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.47.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.47.1(eslint@8.31.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9509,12 +9509,12 @@ snapshots:
     dependencies:
       eslint: 8.31.0
 
-  eslint-plugin-jest@27.2.0(@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(jest@27.0.6)(typescript@4.9.4):
+  eslint-plugin-jest@27.2.0(@typescript-eslint/eslint-plugin@5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(jest@27.0.6)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.31.0)(typescript@5.8.3)
       eslint: 8.31.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@4.9.4))(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/eslint-plugin': 5.47.1(@typescript-eslint/parser@5.47.1(eslint@8.31.0)(typescript@5.8.3))(eslint@8.31.0)(typescript@5.8.3)
       jest: 27.0.6
     transitivePeerDependencies:
       - supports-color
@@ -9555,10 +9555,10 @@ snapshots:
       resolve: 2.0.0-next.6
       string.prototype.matchall: 4.0.12
 
-  eslint-plugin-storybook@0.6.8(eslint@8.31.0)(typescript@4.9.4):
+  eslint-plugin-storybook@0.6.8(eslint@8.31.0)(typescript@5.8.3):
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.31.0)(typescript@5.8.3)
       eslint: 8.31.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
@@ -11543,9 +11543,9 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.3.1
 
-  react-docgen-typescript@2.4.0(typescript@4.9.4):
+  react-docgen-typescript@2.4.0(typescript@5.8.3):
     dependencies:
-      typescript: 4.9.4
+      typescript: 5.8.3
 
   react-docgen@7.1.1:
     dependencies:
@@ -12369,13 +12369,13 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-loader@9.4.2(typescript@4.9.4)(webpack@5.75.0):
+  ts-loader@9.4.2(typescript@5.8.3)(webpack@5.75.0):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.20.1
       micromatch: 4.0.8
       semver: 7.7.4
-      typescript: 4.9.4
+      typescript: 5.8.3
       webpack: 5.75.0(esbuild@0.25.12)(webpack-cli@5.0.1)
 
   tsconfig-paths@3.15.0:
@@ -12395,10 +12395,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsutils@3.21.0(typescript@4.9.4):
+  tsutils@3.21.0(typescript@5.8.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.4
+      typescript: 5.8.3
 
   tty-table@4.2.3:
     dependencies:
@@ -12468,7 +12468,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript@4.9.4: {}
+  typescript@5.8.3: {}
 
   ufo@1.6.3: {}
 

--- a/src/package/components/Search/Search.tsx
+++ b/src/package/components/Search/Search.tsx
@@ -21,21 +21,25 @@ export interface SearchProps<IsMulti extends boolean>
   noOptionsTitle?: string;
 }
 
-export function Search<IsMulti extends boolean>({
-  floatingLabel = "Search",
-  noOptionsTitle = "Invalid search",
-  autoFocus = false,
-  backspaceRemovesValue = true,
-  captureMenuScroll = false,
-  hideSelectedOptions = true,
-  isClearable = true,
-  isLoading = false,
-  isSearchable = true,
-  noOptionsMessage = () => "No results found for this search",
-  placeholder = "",
-  defaultValue,
-  ...rest
-}: SearchProps<IsMulti>) {
+export function Search<IsMulti extends boolean>(
+  props: SearchProps<IsMulti>
+) {
+  // TODO: replaced in PR 19 — file is deleted and rewritten with React Aria
+  const {
+    floatingLabel = "Search",
+    noOptionsTitle = "Invalid search",
+    autoFocus = false,
+    backspaceRemovesValue = true,
+    captureMenuScroll = false,
+    hideSelectedOptions = true,
+    isClearable = true,
+    isLoading = false,
+    isSearchable = true,
+    noOptionsMessage = () => "No results found for this search",
+    placeholder = "",
+    defaultValue,
+    ...rest
+  } = props as any;
   const [invalidSearch, setInvalidSearch] = useState(false);
   return (
     // @ts-ignore

--- a/src/package/components/Search/Search.tsx
+++ b/src/package/components/Search/Search.tsx
@@ -21,9 +21,7 @@ export interface SearchProps<IsMulti extends boolean>
   noOptionsTitle?: string;
 }
 
-export function Search<IsMulti extends boolean>(
-  props: SearchProps<IsMulti>
-) {
+export function Search<IsMulti extends boolean>(props: SearchProps<IsMulti>) {
   // TODO: replaced in PR 19 — file is deleted and rewritten with React Aria
   const {
     floatingLabel = "Search",

--- a/src/package/tsconfig.json
+++ b/src/package/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": false, // emit javascript output files & declarations
     "outDir": "../../dist", // output directory
     "removeComments": false, // strip all comments, set to false for libraries
-    "target": "ES6", // output code format
+    "target": "ES2020", // output code format
 
     // Strict Checks
     "strict": true, // stronger type checking, enables all strict rules

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": false, // emit javascript output files & declarations
     "outDir": "./build/", // output directory
     "removeComments": true, // strip all comments, set to false for libraries
-    "target": "ES6", // output code format
+    "target": "ES2020", // output code format
 
     // Strict Checks
     "strict": true, // stronger type checking, enables all strict rules


### PR DESCRIPTION
## Summary

- Upgrades `typescript` from `4.9.4` → `5.8.3` (pinned, no `^`)
- Bumps `target` in `tsconfig.json` and `src/package/tsconfig.json` from `ES6` → `ES2020`
- Suppresses TS5 generic destructuring error in `Search.tsx` with `as any` (file is replaced in a later PR)
- Pins Node to v22 in the `package-size` workflow — pnpm 11 requires Node 22+, the workflow had no `setup-node` step and was falling back to the runner default (Node 20)

## Notes

The `target` change does not affect consumers yet — the current webpack/rollup pipeline transpiles the output further. The ES2020 output becomes visible to consumers in the tsdown migration PR.

## Checklist

- [x] My changes generate no new warnings
- [x] I've done a self-review of this pull request